### PR TITLE
Fix Application Compatibility and Package Problems on Fedora

### DIFF
--- a/roles/Fedora/meta/check_updates_metadata.yml
+++ b/roles/Fedora/meta/check_updates_metadata.yml
@@ -4,8 +4,8 @@
 
 # Metadata of check_updates.yml
 systems:
-  - name: "Kali"
-    versions: ['2024.2']
+  - name: "Fedora"
+    versions: ['40', '39', '38']
     
 description: "It ensures that systems are kept up-to-date with the latest security
 patches and bug fixes available thorugh package repositories."

--- a/roles/Fedora/meta/check_xz_backdoor_metadata.yml
+++ b/roles/Fedora/meta/check_xz_backdoor_metadata.yml
@@ -7,22 +7,10 @@ systems:
   - name: "Fedora"
     versions: ['40', '39', '38']
     
-description: "XZ Utils is a popular collection of data compression libraries and tools lossless compressors.
-XZ is the main program for compressing and decompressing files in the XZ format, and lblzma is a 
-open source library that provides functions and tools for compression and decompression using the LZMA 
-algorithm."
+description: "XZ Utils is a popular collection of data compression libraries and tools lossless compressors. XZ is the main program for compressing and decompressing files in the XZ format, and lblzma is a open source library that provides functions and tools for compression and decompression using the LZMA algorithm."
      
-rationale: "The vulnerability affects only versions 5.6.0 and 5.6.1 of XZ and Liblzma. 
-It is considered a very serious threat because it allows remote code execution, allowing
-for attackers to run malicious software, access confidential data and gain control on affected 
-systems from anywhere in the world. It is currently detected that the vulnerability affects Kali Linux
-(available between March 26 and 29), openSUSE (from March 7 as of March 28), Fedora 41, Fedora Rawhide, 
-Fedora Linux 40 beta, Debian (in distributions test, unstable and experimental), Arco Linux and Alpine Edge. 
-But very carefully, because additional operating systems and distributions may be added over time. For this 
-reason, this rule is responsible for checking for all linux distributions that do not have installed
-versions 5.6.0 and 5.6.1 of the xz and liblzma programs."
+rationale: "The vulnerability affects only versions 5.6.0 and 5.6.1 of XZ and Liblzma. It is considered a very serious threat because it allows remote code execution, allowing for attackers to run malicious software, access confidential data and gain control on affected systems from anywhere in the world. It is currently detected that the vulnerability affects Kali Linux (available between March 26 and 29), openSUSE (from March 7 as of March 28), Fedora 41, Fedora Rawhide, Fedora Linux 40 beta, Debian (in distributions test, unstable and experimental), Arco Linux and Alpine Edge. But very carefully, because additional operating systems and distributions may be added over time. For this reason, this rule is responsible for checking for all linux distributions that donot have installed versions 5.6.0 and 5.6.1 of the xz and liblzma programs."
 
-remediation: "The recommended mitigation is to immediately downgrade xz and liblzma to a safe version, 
-like version 5.4.6."
+remediation: "The recommended mitigation is to immediately downgrade xz and liblzma to a safe version, like version 5.4.6."
      
 cvss_score: 10.0

--- a/roles/Fedora/tasks/check_updates.yml
+++ b/roles/Fedora/tasks/check_updates.yml
@@ -2,14 +2,14 @@
 # © 2024 marcSerrano2613
 # Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-- name: Ensure there are not pending packages updates
+- name: Check if there are pending updates
   hosts: localhost
-  tasks:     
+  tasks:    
      - name: Include OS-specific variables
-       include_vars: "../vars/{{ ansible_facts.distribution }}.yml"
+       include_vars: "../vars/Fedora.yml"
        
      - name: Check pending packages updates
        include_tasks: ../../common/tasks/check_updates.yml
        vars:
-          check_updates_command: dnf check-update
-          remediation: dnf update
+          check_updates_command: "{{ check_packages_updates }}"
+          remediation: "{{ install_updates }}"

--- a/roles/Fedora/tasks/check_xz_backdoor.yml
+++ b/roles/Fedora/tasks/check_xz_backdoor.yml
@@ -6,7 +6,7 @@
   hosts: localhost
   tasks:
      - name: Include OS-specific variables
-       include_vars: "../vars/Ubuntu.yml"
+       include_vars: "../vars/Fedora.yml"
        
      - name: Include global variables
        include_vars: "../../common/vars/global_vars.yml"

--- a/roles/Fedora/tasks/sudo_check.yml
+++ b/roles/Fedora/tasks/sudo_check.yml
@@ -9,7 +9,7 @@
        include_vars: "../../common/vars/global_vars.yml"
           
      - name: Check if sudo is installed
-       include_tasks: check_if_package_not_installed.yml
+       include_tasks: "../../common/tasks/check_if_package_not_installed.yml"
        vars:
           package_name: "{{ sudo_package }}"
           remediation: dnf install

--- a/roles/Fedora/vars/Fedora.yml
+++ b/roles/Fedora/vars/Fedora.yml
@@ -4,10 +4,9 @@
 
 #Files
 
-
 #Packages
 
-
 # Commands
-update_packages_command: update_packages_dnf
-check_updates_command: check_updates_dnf
+check_packages_updates: "dnf updateinfo list available"
+install_updates: "dnf upgrade"
+install_xz_command: "dnf install xz=5.4.6"

--- a/roles/Ubuntu/meta/check_updates_metadata.yml
+++ b/roles/Ubuntu/meta/check_updates_metadata.yml
@@ -6,8 +6,6 @@
 systems:
   - name: "Ubuntu"
     versions: ['24.04', '23.10', '22.04', '20.04']
-  - name: "Kali"
-    versions: ['2024.2']
     
 description: "It ensures that systems are kept up-to-date with the latest security
 patches and bug fixes available thorugh package repositories."

--- a/roles/Ubuntu/meta/sudo_check_metadata.yml
+++ b/roles/Ubuntu/meta/sudo_check_metadata.yml
@@ -6,8 +6,6 @@
 systems:
   - name: "Ubuntu"
     versions: ['24.04', '23.10', '22.04', '20.04']
-  - name: "Fedora"
-    versions: ['40', '39', '38']
     
 description: "sudo allows a permitted user to execute a command as the superuser or another user, as 
      specified by the security policy. The invoking user's real (not effective) userID is used to determine

--- a/roles/Ubuntu/tasks/check_updates.yml
+++ b/roles/Ubuntu/tasks/check_updates.yml
@@ -6,9 +6,6 @@
   hosts: localhost
   tasks:
      - name: Include OS-specific variables
-       include_vars: "../../common/vars/global_vars.yml"
-          
-     - name: Include OS-specific variables
        include_vars: "../vars/{{ ansible_facts.distribution }}.yml"
        
      - name: Check pending packages updates

--- a/roles/Ubuntu/vars/Ubuntu.yml
+++ b/roles/Ubuntu/vars/Ubuntu.yml
@@ -4,11 +4,9 @@
 
 #Files
 
-
 #Packages
 avahi_daemon_package: avahi-daemon
 
-
 # Commands
 check_packages_updates: "apt list --upgradable"
-install_xz_command: "apt install xz-utils=5.4.6"
+install_xz_command: "apt install xz=5.4.6"

--- a/roles/common/tasks/check_packages_versions.yml
+++ b/roles/common/tasks/check_packages_versions.yml
@@ -9,4 +9,4 @@
 - name: Check package versions are versions vulnerable
   ansible.builtin.fail:
     msg: "Package {{ package_name }} version {{ ansible_facts.packages[package_name][0].version }} is installed. [Remediation] {{ remediation }}"
-  when: ansible_facts.packages[package_name][0].version | regex_replace('-.*', '') in versions_xz
+  when: ansible_facts.packages[package_name][0].version | regex_replace('-.*', '')  in versions_xz

--- a/roles/common/vars/global_vars.yml
+++ b/roles/common/vars/global_vars.yml
@@ -7,9 +7,8 @@ passwd_file: "/etc/passwd"
 
 #Packages
 sudo_package: sudo
-versions_xz_vulnerable: [5.6.0, 5.6.1]
 versions_xz: [5.6.0, 5.6.1]
-xz_package: xz-utils
+xz_package: xz
 
 # Commands
 


### PR DESCRIPTION
## Objectives 🎯
- Correct Distribution Name Handling: Update the application to correctly recognize and handle the full distribution names, such as "Fedora Linux," to ensure compatibility checks and package management operations are performed accurately based on the exact distribution name.

- Package Name Alignment: Adjust the application to handle package name differences between distributions, such as using xz for Fedora instead of xz-utils, to avoid errors during package installation and verification.

- Playbook Compatibility: Modify the Ansible playbooks to ensure they are compatible with multiple distributions, including both Ubuntu and Fedora. This includes updating package names and configuration details to reflect the differences between these distributions.
  
## Previous Behaviour ⏪
- Distribution Name Handling: The application was unable to accurately process the distribution name "Fedora Linux," incorrectly treating it as "Fedora." This led to issues in compatibility checks and package management because the exact distribution name was critical for proper functionality.

- Package Name Mismatch: The application expected the package name xz-utils, which is used in Ubuntu but not in Fedora. Fedora uses the package name xz for similar functionality. This mismatch caused errors when the application tried to install or verify packages.

- Incompatibility with Ubuntu Playbook: The playbooks, such as sudo_check.yml, designed for Ubuntu, failed when executed on Fedora due to the use of Ubuntu-specific packages and configurations. This resulted in errors and failures in running tasks intended for Fedora.

## New Behaviour 🌟
- Correct Distribution Name Handling: The application now correctly identifies and handles full distribution names, such as "Fedora Linux," ensuring that compatibility checks and package management operations are executed correctly based on the precise distribution name.

- Package Name Alignment: The application has been updated to recognize and handle package name differences. For Fedora, the application now correctly uses xz instead of xz-utils, avoiding installation and verification errors.

- Playbook Compatibility: Ansible playbooks have been revised to support both Ubuntu and Fedora. Package names and configurations are now adjusted based on the target distribution, ensuring smooth execution of tasks across different Linux distributions.
  
## Checklist 📝
- [x] I have reviewed the code to ensure it follows the project style guidelines.
- [x] I have performed local tests of the changes made.

