### PR TITLE
Fix install package wkhtmltopdf

### DIFF
--- a/install_wkhtmltopdf.yml
+++ b/install_wkhtmltopdf.yml
@@ -1,0 +1,13 @@
+---
+# © 2024 marcSerrano2613
+# Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+- name: Ensure wkhtmltopdf is installed
+  hosts: localhost
+  become: yes
+  tasks:
+    - name: Install wkhtmltopdf using the appropriate package manager
+      package:
+        name: wkhtmltopdf
+        state: present
+

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,6 @@ install_python_package matplotlib
 install_python_package pdfplumber
 
 # Install wkhtmltopdf and its dependencies
-print_message "Installing wkhtmltopdf..."
-sudo apt-get install -y wkhtmltopdf 
+ansible-playbook install_wkhtmltopdf.yml --ask-become-pass
 
 print_message "Installation completed!"


### PR DESCRIPTION
Objectives 🎯
- Implement a playbook to handle the installation of wkhtmltopdf across different Linux distributions.

Previous Behaviour ⏪
- The playbook or script was designed to install wkhtmltopdf using a single package manager command (e.g., apt-get for Ubuntu) without considering the need for distribution-specific adjustments. For Fedora, the package manager dnf was not used, leading to failed installation attempts.

New Behaviour 🌟
- Detection of Distribution: The playbook now detects the Linux distribution running on the system, whether it’s Ubuntu, Fedora, or another supported distribution.
- Conditional Installation:
For Ubuntu/Debian systems: Uses apt or apt-get to install wkhtmltopdf.
For Fedora systems: Uses dnf to install wkhtmltopdf.

 
## Checklist 📝
- [x] I have reviewed the code to ensure it follows the project style guidelines.
- [x] I have performed local tests of the changes made.
