### PR TITLE
Fix detection xz

### DIFF
--- a/roles/Fedora/vars/Fedora.yml
+++ b/roles/Fedora/vars/Fedora.yml
@@ -10,3 +10,4 @@
 check_packages_updates: "dnf updateinfo list available"
 install_updates: "dnf upgrade"
 install_xz_command: "dnf install xz=5.4.6"
+xz_package: xz

--- a/roles/Ubuntu/vars/Ubuntu.yml
+++ b/roles/Ubuntu/vars/Ubuntu.yml
@@ -10,3 +10,4 @@ avahi_daemon_package: avahi-daemon
 # Commands
 check_packages_updates: "apt list --upgradable"
 install_xz_command: "apt install xz=5.4.6"
+xz_package: xz-utils

--- a/roles/common/vars/global_vars.yml
+++ b/roles/common/vars/global_vars.yml
@@ -8,7 +8,6 @@ passwd_file: "/etc/passwd"
 #Packages
 sudo_package: sudo
 versions_xz: [5.6.0, 5.6.1]
-xz_package: xz
 
 # Commands
 


### PR DESCRIPTION
**Objectives** 🎯
The main goal of this PR is to ensure that the Ansible playbook correctly installs the xz package across different Linux distributions, specifically Ubuntu and Fedora. This will be achieved by using OS-specific package names rather than a single, common variable. The objectives include updating the playbook to handle these differences and ensuring seamless compatibility across both operating systems.

**Previous Behaviour**⏪
Previously, the playbook used a common variable for the xz package name across all supported Linux distributions. However, this approach caused issues on Ubuntu systems, where the package is named xz-utils, leading to failures during provisioning. On Fedora, the package was correctly detected and installed as xz, but the mismatch on Ubuntu prevented the playbook from functioning as expected on that platform.

**New Behaviour** 🌟
After the changes, the playbook now defines the xz package name using OS-specific variables: xz-utils for Ubuntu and xz for Fedora. This ensures that the correct package is installed regardless of the underlying distribution, improving the playbook's reliability and cross-platform compatibility. The updated playbook has been tested on both Ubuntu and Fedora, confirming that the package is correctly identified and installed on both systems.

 
## Checklist 📝
- [x] I have reviewed the code to ensure it follows the project style guidelines.
- [x] I have performed local tests of the changes made.
